### PR TITLE
Make it possible to whitelist user agents.

### DIFF
--- a/lib/rack_password.rb
+++ b/lib/rack_password.rb
@@ -48,7 +48,7 @@ module RackPassword
     end
 
     def valid?
-      valid_path? || valid_code?(@request.cookies[@options[:key].to_s]) || valid_ip?
+      valid_path? || valid_code?(@request.cookies[@options[:key].to_s]) || valid_ip? || valid_ua?
     end
 
     def valid_ip?
@@ -59,6 +59,11 @@ module RackPassword
     def valid_path?
       match = @request.path =~ /\.xml|\.rss|\.json/ || @request.path =~ @options[:path_whitelist]
       !!match
+    end
+
+    def valid_ua?
+      return false if @options[:ua_whitelist].nil?
+      @options[:ua_whitelist].include? @request.user_agent
     end
 
     def valid_code? code

--- a/spec/lib/rack_password/block_validator_spec.rb
+++ b/spec/lib/rack_password/block_validator_spec.rb
@@ -58,4 +58,19 @@ describe RackPassword::BlockValidator do
       expect(bv.valid_code?("incorrect_secret")).to be(false)
     end
   end
+
+  describe "valid user agent" do
+    let(:options) { Hash[ua_whitelist: ["some_ua/1.8"]] }
+    let(:request) { double "Request", user_agent: "some_ua/1.8" }
+
+    it "be true when user agent is whitelisted" do
+      bv = RackPassword::BlockValidator.new(options, request)
+      expect(bv.valid_ua?).to be(true)
+    end
+
+    it "be false when user agent is not whitelisted" do
+      bv = RackPassword::BlockValidator.new({}, request)
+      expect(bv.valid_ua?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Paths, IDs can be whitelisted already - why not UA strings?

(Idea to discuss: making it possible to pass not only exact-match UA strings, but rather regular expressions.)