### PR TITLE
Add option to define custom validation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ From now on, your staging app should prompt for `janusz` password before you acc
 You can also provide custom validator:
 
 ```
-config.middleware.use RackPassword::Block, auth_codes: ['janusz'], custom_rule: Proc.new { |request| request.env['HTTP_USER_AGENT'].include?('facebook') }
+config.middleware.use RackPassword::Block, auth_codes: ['janusz'], custom_rule: proc { |request| request.env['HTTP_USER_AGENT'].include?('facebook') }
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ config.middleware.use RackPassword::Block, auth_codes: ['janusz']
 
 From now on, your staging app should prompt for `janusz` password before you access it.
 
+You can also provide custom validator:
+
+```
+config.middleware.use RackPassword::Block, auth_codes: ['janusz'], custom_rule: Proc.new { |request| request.env['HTTP_USER_AGENT'].include?('facebook') }
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/netguru/rack_password/fork )

--- a/lib/rack_password.rb
+++ b/lib/rack_password.rb
@@ -48,7 +48,7 @@ module RackPassword
     end
 
     def valid?
-      valid_path? || valid_code?(@request.cookies[@options[:key].to_s]) || valid_ip?
+      valid_path? || valid_code?(@request.cookies[@options[:key].to_s]) || valid_ip? || custom_rule?
     end
 
     def valid_ip?
@@ -63,6 +63,11 @@ module RackPassword
     def valid_code? code
       return false if @options[:auth_codes].nil?
       @options[:auth_codes].include? code
+    end
+
+    def custom_rule?
+      return false if @options[:custom_rule].nil?
+      !!@options[:custom_rule].call
     end
   end
 

--- a/lib/rack_password.rb
+++ b/lib/rack_password.rb
@@ -67,7 +67,7 @@ module RackPassword
 
     def custom_rule?
       return false if @options[:custom_rule].nil?
-      !!@options[:custom_rule].call
+      !!@options[:custom_rule].call(@request)
     end
   end
 

--- a/lib/rack_password.rb
+++ b/lib/rack_password.rb
@@ -48,7 +48,7 @@ module RackPassword
     end
 
     def valid?
-      valid_path? || valid_code?(@request.cookies[@options[:key].to_s]) || valid_ip? || custom_rule?
+      valid_path? || valid_code?(@request.cookies[@options[:key].to_s]) || valid_ip? || valid_custom_rule?
     end
 
     def valid_ip?
@@ -65,7 +65,7 @@ module RackPassword
       @options[:auth_codes].include? code
     end
 
-    def custom_rule?
+    def valid_custom_rule?
       return false if @options[:custom_rule].nil?
       !!@options[:custom_rule].call(@request)
     end

--- a/lib/rack_password/version.rb
+++ b/lib/rack_password/version.rb
@@ -1,3 +1,3 @@
 module RackPassword
-  VERSION = "1.2"
+  VERSION = "1.3"
 end

--- a/spec/lib/rack_password/block_validator_spec.rb
+++ b/spec/lib/rack_password/block_validator_spec.rb
@@ -60,24 +60,34 @@ describe RackPassword::BlockValidator do
   end
 
   describe "proc control" do
-    context 'with proc allowing to pass' do
+    context "with proc allowing to pass" do
       let(:options) { Hash[auth_codes: ["secret"], key: :staging_auth, custom_rule: proc { true } ] }
       let(:request) { double "Request" }
 
-      it "be true when proc evaluates to true" do
+      it "is true when proc evaluates to true" do
         bv = RackPassword::BlockValidator.new(options, request)
-        expect(bv.custom_rule?).to be(true)
+        expect(bv.valid_custom_rule?).to be(true)
+      end
+
+      it "is true when proc returns true" do
+        bv = RackPassword::BlockValidator.new({custom_rule: proc { return true }}, request)
+        expect(bv.valid_custom_rule?).to be(true)
       end
     end
 
-    context 'with proc set to deny-all' do
+    context "with proc set to deny-all" do
       let(:options) { Hash[auth_codes: ["secret"], key: :staging_auth, custom_rule: proc { false } ] }
-      let(:request) { double "Request", path: '/', ip: "127.0.0.1", cookies: { } }
+      let(:request) { double "Request", path: "/", ip: "127.0.0.1", cookies: { } }
 
-      it "be true when proc evaluates to true" do
+      it "is true when proc evaluates to true" do
         bv = RackPassword::BlockValidator.new(options, request)
-        expect(bv.custom_rule?).to be(false)
+        expect(bv.valid_custom_rule?).to be(false)
         expect(bv.valid?).to be(false)
+      end
+
+      it "is false when proc returns false" do
+        bv = RackPassword::BlockValidator.new({custom_rule: proc { return false }}, request)
+        expect(bv.valid_custom_rule?).to be(true)
       end
     end
   end

--- a/spec/lib/rack_password/block_validator_spec.rb
+++ b/spec/lib/rack_password/block_validator_spec.rb
@@ -61,7 +61,7 @@ describe RackPassword::BlockValidator do
 
   describe "proc control" do
     context 'with proc allowing to pass' do
-      let(:options) { Hash[auth_codes: ["secret"], key: :staging_auth, custom_rule: Proc.new { true } ] }
+      let(:options) { Hash[auth_codes: ["secret"], key: :staging_auth, custom_rule: proc { true } ] }
       let(:request) { double "Request" }
 
       it "be true when proc evaluates to true" do
@@ -71,7 +71,7 @@ describe RackPassword::BlockValidator do
     end
 
     context 'with proc set to deny-all' do
-      let(:options) { Hash[auth_codes: ["secret"], key: :staging_auth, custom_rule: Proc.new { false } ] }
+      let(:options) { Hash[auth_codes: ["secret"], key: :staging_auth, custom_rule: proc { false } ] }
       let(:request) { double "Request", path: '/', ip: "127.0.0.1", cookies: { } }
 
       it "be true when proc evaluates to true" do

--- a/spec/lib/rack_password/block_validator_spec.rb
+++ b/spec/lib/rack_password/block_validator_spec.rb
@@ -62,7 +62,7 @@ describe RackPassword::BlockValidator do
   describe "proc control" do
     context "with proc allowing to pass" do
       let(:options) { Hash[auth_codes: ["secret"], key: :staging_auth, custom_rule: proc { true } ] }
-      let(:request) { double "Request" }
+      let(:request) { double "Request", path: "/", ip: "127.0.0.1", cookies: { } }
 
       it "is true when proc evaluates to true" do
         bv = RackPassword::BlockValidator.new(options, request)
@@ -70,8 +70,18 @@ describe RackPassword::BlockValidator do
       end
 
       it "is true when proc returns true" do
-        bv = RackPassword::BlockValidator.new({custom_rule: proc { return true }}, request)
+        bv = RackPassword::BlockValidator.new({custom_rule: proc { true }}, request)
         expect(bv.valid_custom_rule?).to be(true)
+      end
+
+      it 'is true when other rules return false' do
+        bv = RackPassword::BlockValidator.new(options, request)
+        expect(bv.valid_path?).to be(false)
+        expect(bv.valid_code?('')).to be(false)
+        expect(bv.valid_ip?).to be(false)
+
+        expect(bv.valid_custom_rule?).to be(true)
+        expect(bv.valid?).to be(true)
       end
     end
 
@@ -86,8 +96,8 @@ describe RackPassword::BlockValidator do
       end
 
       it "is false when proc returns false" do
-        bv = RackPassword::BlockValidator.new({custom_rule: proc { return false }}, request)
-        expect(bv.valid_custom_rule?).to be(true)
+        bv = RackPassword::BlockValidator.new({custom_rule: proc { false }}, request)
+        expect(bv.valid_custom_rule?).to be(false)
       end
     end
   end

--- a/spec/lib/rack_password/block_validator_spec.rb
+++ b/spec/lib/rack_password/block_validator_spec.rb
@@ -58,4 +58,27 @@ describe RackPassword::BlockValidator do
       expect(bv.valid_code?("incorrect_secret")).to be(false)
     end
   end
+
+  describe "proc control" do
+    context 'with proc allowing to pass' do
+      let(:options) { Hash[auth_codes: ["secret"], key: :staging_auth, custom_rule: Proc.new { true } ] }
+      let(:request) { double "Request" }
+
+      it "be true when proc evaluates to true" do
+        bv = RackPassword::BlockValidator.new(options, request)
+        expect(bv.custom_rule?).to be(true)
+      end
+    end
+
+    context 'with proc set to deny-all' do
+      let(:options) { Hash[auth_codes: ["secret"], key: :staging_auth, custom_rule: Proc.new { false } ] }
+      let(:request) { double "Request", path: '/', ip: "127.0.0.1", cookies: { } }
+
+      it "be true when proc evaluates to true" do
+        bv = RackPassword::BlockValidator.new(options, request)
+        expect(bv.custom_rule?).to be(false)
+        expect(bv.valid?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/lib/rack_password/block_validator_spec.rb
+++ b/spec/lib/rack_password/block_validator_spec.rb
@@ -74,7 +74,7 @@ describe RackPassword::BlockValidator do
         expect(bv.valid_custom_rule?).to be(true)
       end
 
-      it 'is true when other rules return false' do
+      it "is true when other rules return false" do
         bv = RackPassword::BlockValidator.new(options, request)
         expect(bv.valid_path?).to be(false)
         expect(bv.valid_code?('')).to be(false)


### PR DESCRIPTION
This PR adds ability to define custom validation rule using `Proc`:

```
config.middleware.use RackPassword::Block, auth_codes: ['janusz'], custom_rule: proc { |request| request.env['HTTP_USER_AGENT'].include?('facebook') }
```