### PR TITLE
Show application name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![](http://img.shields.io/travis/netguru/rack_password.svg?style=flat-square)](ps://travis-ci.org/netguru/rack_password)
 
 Small rack middleware to block your site from unwanted vistors. A little bit more convenient than basic auth - browser will ask you once for the password and then set a cookie to remember you - unlike the http basic auth it wont prompt you all the time.
+If used as RoR middleware, it will show application name above the sign in form. 
 
 ## Installation
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  ruby:
+    version: 2.1.5

--- a/lib/rack_password.rb
+++ b/lib/rack_password.rb
@@ -36,6 +36,12 @@ module RackPassword
 
     def read_success_view
       @success_view ||= File.open(File.join(File.dirname(__FILE__), "views", "block_middleware.html")).read
+      fill_in_application_name(@success_view)
+    end
+
+    def fill_in_application_name(view)
+      app_name = defined?(Rails) ? Rails.application.class.parent_name : ""
+      view.sub('__App_Name__', app_name)
     end
   end
 

--- a/lib/views/block_middleware.html
+++ b/lib/views/block_middleware.html
@@ -5,6 +5,7 @@
       <div class="row-fluid">
         <div class="span4"></div>
         <div class="span4">
+          <h2>__App_Name__</h2>
           <legend>Sign in</legend>
           <form action="" method="post" class="form-inline">
             <input type="password" placeholder="Password..." name="code" autofocus/>

--- a/spec/lib/rack_password/block_spec.rb
+++ b/spec/lib/rack_password/block_spec.rb
@@ -13,6 +13,14 @@ module RackPassword
       it "return html" do
         expect(block.success_rack_response[2][0]).to include("password")
       end
+
+      it "fills in application name if used as Rails middleware" do
+        app_name = 'TestAppName'
+        class Rails; end
+        allow(Rails).to receive_message_chain(:application, :class, :parent_name) { app_name }
+        
+        expect(block.success_rack_response[2][0]).to include(app_name)
+      end
     end
   end
 end


### PR DESCRIPTION
Because not always one can determine what application he/she is accessing just by seeing the url address, this will show the AppName above the form for Rails applications. For other types of application, no application name is showed. 