### PR TITLE
Add parameter to force root cookie path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ You can also provide `cookie_domain` option to override cookie domain. This way 
 config.middleware.use RackPassword::Block, auth_codes: ['janusz'], cookie_domain: '.somedomain.com'
 ```
 
-The above code will make the authorization cookie shared across all `somedomain.com` subdomains, e.g. `a.somedomain.com` and `b.somedomain.com`. 
+The above code will make the authorization cookie shared across all `somedomain.com` subdomains, e.g. `a.somedomain.com` and `b.somedomain.com`.
+
+To make sure the cookies are used for all the pages from selected (sub)domains, use `force_cookie_root_path` option - it helps to reduce the risk of unexpected behaviour for some browsers.
 
 ## Common problems
 - If you use server ip address instead of domain name to visit your webpage using chrome, rack_password will not accept any password, including the correct one. As a workaround, please use wildcard DNS service, such as [xip.io](http://xip.io/) or set `cookie_domain` option to match server IP address.

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new
 

--- a/lib/rack_password.rb
+++ b/lib/rack_password.rb
@@ -1,4 +1,5 @@
-require "rack_password/version"
+require 'rack_password/version'
+require 'rack'
 
 module RackPassword
 

--- a/lib/rack_password.rb
+++ b/lib/rack_password.rb
@@ -2,80 +2,94 @@ require 'rack_password/version'
 require 'rack'
 
 module RackPassword
-
   class Block
-
-    def initialize app, options = {}
+    def initialize(app, options = {})
       @app = app
       @options = {
-        :key => :staging_auth,
-        :code_param => :code
-        }.merge options
+        code_param: :code,
+        key: :staging_auth
+      }.merge(options)
     end
 
-    def call env
-      request = Rack::Request.new env
+    def call(env)
+      request = ::Rack::Request.new env
 
       bv = BlockValidator.new(@options, request)
       return @app.call(env) if bv.valid?
 
+      code = request.params[@options[:code_param].to_s]
 
-      if request.post? and bv.valid_code?(request.params[@options[:code_param].to_s]) # If post method check :code_param value
+      if request.post? && bv.valid_code?(code)
         domain = @options[:cookie_domain]
         domain ||= request.host == 'localhost' ? '' : ".#{request.host}"
-      [301, {'Location' => request.path, 'Set-Cookie' => "#{@options[:key]}=#{request.params[@options[:code_param].to_s]}; domain=#{domain}; expires=30-Dec-2039 23:59:59 GMT"}, ['']] # Redirect if code is valid
+
+        [301, { 'Location' => request.path, 'Set-Cookie' => cookie_params(domain, code) }, ['']]
       else
         success_rack_response
       end
     end
 
-    def success_rack_response
-      [200, {'Content-Type' => 'text/html'}, [read_success_view]]
-    end
-
     private
 
+    def cookie_params(domain, code)
+      "#{@options[:key]}=#{code}; "\
+      "domain=#{domain}; "\
+      'expires=30-Dec-2039 23:59:59 GMT; '\
+      "#{cookie_path_attribute}"
+    end
+
+    def cookie_path_attribute
+      'path=/' if @options[:force_cookie_root_path]
+    end
+
     def read_success_view
-      @success_view ||= File.open(File.join(File.dirname(__FILE__), "views", "block_middleware.html")).read
+      @success_view ||= File.open(File.join(File.dirname(__FILE__), 'views', 'block_middleware.html')).read
       fill_in_application_name(@success_view)
     end
 
     def fill_in_application_name(view)
-      app_name = defined?(Rails) ? Rails.application.class.parent_name : ""
+      app_name = defined?(Rails) ? Rails.application.class.parent_name : ''
       view.sub('__App_Name__', app_name)
+    end
+
+    def success_rack_response
+      [200, { 'Content-Type' => 'text/html' }, [read_success_view]]
     end
   end
 
   class BlockValidator
     attr_accessor :options, :request
 
-    def initialize options, request
+    def initialize(options, request)
       @options = options
       @request = request
     end
 
     def valid?
-      valid_path? || valid_code?(@request.cookies[@options[:key].to_s]) || valid_ip? || valid_custom_rule?
+      valid_path? || valid_code?(@request.cookies[@options[:key].to_s]) ||
+        valid_ip? || valid_custom_rule?
     end
 
     def valid_ip?
       return false if @options[:ip_whitelist].nil?
-      @options[:ip_whitelist].include? @request.ip.to_s
+
+      @options[:ip_whitelist].include?(@request.ip.to_s)
     end
 
     def valid_path?
       !!(@request.path =~ @options[:path_whitelist])
     end
 
-    def valid_code? code
+    def valid_code?(code)
       return false if @options[:auth_codes].nil?
-      @options[:auth_codes].include? code
+
+      @options[:auth_codes].include?(code)
     end
 
     def valid_custom_rule?
       return false if @options[:custom_rule].nil?
+
       !!@options[:custom_rule].call(@request)
     end
   end
-
 end

--- a/lib/rack_password/version.rb
+++ b/lib/rack_password/version.rb
@@ -1,3 +1,3 @@
 module RackPassword
-  VERSION = "1.3"
+  VERSION = '1.3'.freeze
 end

--- a/rack_password.gemspec
+++ b/rack_password.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_dependency "rack"
+
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "webmock"

--- a/rack_password.gemspec
+++ b/rack_password.gemspec
@@ -1,27 +1,29 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rack_password/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "rack_password"
+  spec.name          = 'rack_password'
   spec.version       = RackPassword::VERSION
-  spec.authors       = ["Marcin Stecki"]
-  spec.email         = ["marcin@netguru.pl"]
-  spec.summary       = %q{Small rack middleware to block your site from unwanted vistors.}
-  spec.description   = %q{Small rack middleware to block your site from unwanted vistors. A little bit more convenient than basic auth - browser will ask you once for the password and then set a cookie to remember you - unlike the http basic auth it wont prompt you all the time.}
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.authors       = ['Marcin Stecki']
+  spec.email         = ['marcin@netguru.pl']
+  spec.summary       = 'Small rack middleware to block your site from unwanted vistors.'
+  spec.description   = 'Small rack middleware to block your site from unwanted vistors. '\
+                       'A little bit more convenient than basic auth - browser will ask '\
+                       'you once for the password and then set a cookie to remember you '\
+                       '- unlike the http basic auth it wont prompt you all the time.'
+  spec.homepage      = ''
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "rack"
+  spec.add_dependency 'rack'
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "webmock"
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'webmock'
 end

--- a/spec/lib/rack_password/block_spec.rb
+++ b/spec/lib/rack_password/block_spec.rb
@@ -2,24 +2,64 @@ require 'spec_helper'
 
 module RackPassword
   describe Block do
+    let(:app_name) { 'TestAppName' }
 
-    describe "success rack response" do
-      let(:block){ Block.new("app") }
+    before do
+      class Rails; end
+      allow(Rails).to receive_message_chain(:application, :class, :parent_name) { app_name }
+      allow(Rack::Request).to receive(:new).and_return(request)
+    end
 
-      it "return 200 status code" do
-        expect(block.success_rack_response[0]).to eq 200
+    describe 'for not post requests' do
+      let(:block) { Block.new('app', auth_codes: ['Janusz']) }
+      let(:request) do
+        double(
+          cookies: {},
+          host: 'localhost',
+          params: { 'code' => 'Janusz' },
+          path: '/',
+          post?: false
+        )
       end
 
-      it "return html" do
-        expect(block.success_rack_response[2][0]).to include("password")
+      it 'returns 200 status code' do
+        expect(block.call(request)[0]).to eq(200)
       end
 
-      it "fills in application name if used as Rails middleware" do
-        app_name = 'TestAppName'
-        class Rails; end
-        allow(Rails).to receive_message_chain(:application, :class, :parent_name) { app_name }
-        
-        expect(block.success_rack_response[2][0]).to include(app_name)
+      it 'returns html' do
+        expect(block.call(request)[2][0]).to include('password')
+      end
+
+      it 'fills in application name if used as Rails middleware' do
+        expect(block.call(request)[2][0]).to include(app_name)
+      end
+    end
+
+    describe 'for post requests' do
+      let(:request) do
+        double(
+          cookies: {},
+          host: 'localhost',
+          params: { 'code' => 'Janusz' },
+          path: '/',
+          post?: true
+        )
+      end
+
+      context 'when requests contain proper auth code' do
+        let(:block) { Block.new('app', { auth_codes: ['Janusz'] }) }
+
+        it 'returns 301 status code' do
+          expect(block.call(request)[0]).to eq(301)
+        end
+      end
+
+      context 'when requests contain invalid auth code' do
+        let(:block) { Block.new('app', { auth_codes: ['Janusz123'] }) }
+
+        it 'returns html' do
+          expect(block.call(request)[2][0]).to include('password')
+        end
       end
     end
   end

--- a/spec/lib/rack_password/block_spec.rb
+++ b/spec/lib/rack_password/block_spec.rb
@@ -52,6 +52,22 @@ module RackPassword
         it 'returns 301 status code' do
           expect(block.call(request)[0]).to eq(301)
         end
+
+        context 'and when "force_cookie_root_path" not used' do
+          it 'does not set root path for the cookie' do
+            expect(block.call(request)[1]['Set-Cookie']).to_not include('path=/')
+          end
+        end
+
+        context 'and when "force_cookie_root_path" used' do
+          let(:block) do
+            Block.new('app', { auth_codes: ['Janusz'], force_cookie_root_path: true })
+          end
+
+          it 'sets root path for the cookie' do
+            expect(block.call(request)[1]['Set-Cookie']).to include('path=/')
+          end
+        end
       end
 
       context 'when requests contain invalid auth code' do

--- a/spec/lib/rack_password/block_validator_spec.rb
+++ b/spec/lib/rack_password/block_validator_spec.rb
@@ -2,34 +2,35 @@ require 'spec_helper'
 require 'rack_password'
 
 describe RackPassword::BlockValidator do
-  let(:options){ Hash.new }
+  let(:options) { {} }
 
-  describe "valid ip" do
-    let(:options) { Hash[ip_whitelist: ["127.0.0.1"]] }
-    it "be true when ip is whitelisted" do
-      request = double "Request", ip: "127.0.0.1"
+  describe 'valid ip' do
+    let(:options) { Hash[ip_whitelist: ['127.0.0.1']] }
+
+    it 'be true when ip is whitelisted' do
+      request = double 'Request', ip: '127.0.0.1'
       bv = RackPassword::BlockValidator.new(options, request)
       expect(bv.valid_ip?).to be(true)
     end
 
-    it "be false when ip is not whitelisted" do
-      request = double "Request", ip: "192.168.0.1"
+    it 'be false when ip is not whitelisted' do
+      request = double 'Request', ip: '192.168.0.1'
       bv = RackPassword::BlockValidator.new(options, request)
       expect(bv.valid_ip?).to be(false)
     end
   end
 
-  describe "valid path" do
-    it "be true when path is whitelisted" do
-      options[:path_whitelist] = /secret\/gate/
-      request = double "Request", path: "secret/gate"
+  describe 'valid path' do
+    it 'be true when path is whitelisted' do
+      options[:path_whitelist] = %r{secret/gate}
+      request = double 'Request', path: 'secret/gate'
       bv = RackPassword::BlockValidator.new(options, request)
       expect(bv.valid_path?).to be(true)
     end
 
-    it "be false when path contains xml/rss/json resource" do
+    it 'be false when path contains xml/rss/json resource' do
       %w[janusz.xml lukasz.rss wykop.json].each do |asset|
-        request = double "Request", path: asset
+        request = double 'Request', path: asset
         bv = RackPassword::BlockValidator.new(options, request)
         expect(bv.valid_path?).to be(false)
       end
@@ -37,44 +38,44 @@ describe RackPassword::BlockValidator do
 
     it "be false when path doesn't looks like asset" do
       %w[products orders users].each do |asset|
-        request = double "Request", path: asset
+        request = double 'Request', path: asset
         bv = RackPassword::BlockValidator.new(options, request)
         expect(bv.valid_path?).to be(false)
       end
     end
   end
 
-  describe "valid code" do
-    let(:options) { Hash[auth_codes: ["secret"], key: :staging_auth] }
-    let(:request) { double "Request" }
+  describe 'valid code' do
+    let(:options) { Hash[auth_codes: ['secret'], key: :staging_auth] }
+    let(:request) { double 'Request' }
 
-    it "be true when code is correct" do
+    it 'be true when code is correct' do
       bv = RackPassword::BlockValidator.new(options, request)
-      expect(bv.valid_code?("secret")).to be(true)
+      expect(bv.valid_code?('secret')).to be(true)
     end
 
-    it "be false when code is incorrect" do
+    it 'be false when code is incorrect' do
       bv = RackPassword::BlockValidator.new(options, request)
-      expect(bv.valid_code?("incorrect_secret")).to be(false)
+      expect(bv.valid_code?('incorrect_secret')).to be(false)
     end
   end
 
-  describe "proc control" do
-    context "with proc allowing to pass" do
-      let(:options) { Hash[auth_codes: ["secret"], key: :staging_auth, custom_rule: proc { true } ] }
-      let(:request) { double "Request", path: "/", ip: "127.0.0.1", cookies: { } }
+  describe 'proc control' do
+    context 'with proc allowing to pass' do
+      let(:options) { Hash[auth_codes: ['secret'], key: :staging_auth, custom_rule: proc { true }] }
+      let(:request) { double 'Request', path: '/', ip: '127.0.0.1', cookies: {} }
 
-      it "is true when proc evaluates to true" do
+      it 'is true when proc evaluates to true' do
         bv = RackPassword::BlockValidator.new(options, request)
         expect(bv.valid_custom_rule?).to be(true)
       end
 
-      it "is true when proc returns true" do
-        bv = RackPassword::BlockValidator.new({custom_rule: proc { true }}, request)
+      it 'is true when proc returns true' do
+        bv = RackPassword::BlockValidator.new({ custom_rule: proc { true } }, request)
         expect(bv.valid_custom_rule?).to be(true)
       end
 
-      it "is true when other rules return false" do
+      it 'is true when other rules return false' do
         bv = RackPassword::BlockValidator.new(options, request)
         expect(bv.valid_path?).to be(false)
         expect(bv.valid_code?('')).to be(false)
@@ -85,18 +86,18 @@ describe RackPassword::BlockValidator do
       end
     end
 
-    context "with proc set to deny-all" do
-      let(:options) { Hash[auth_codes: ["secret"], key: :staging_auth, custom_rule: proc { false } ] }
-      let(:request) { double "Request", path: "/", ip: "127.0.0.1", cookies: { } }
+    context 'with proc set to deny-all' do
+      let(:options) { Hash[auth_codes: ['secret'], key: :staging_auth, custom_rule: proc { false }] }
+      let(:request) { double 'Request', path: '/', ip: '127.0.0.1', cookies: {} }
 
-      it "is true when proc evaluates to true" do
+      it 'is true when proc evaluates to true' do
         bv = RackPassword::BlockValidator.new(options, request)
         expect(bv.valid_custom_rule?).to be(false)
         expect(bv.valid?).to be(false)
       end
 
-      it "is false when proc returns false" do
-        bv = RackPassword::BlockValidator.new({custom_rule: proc { false }}, request)
+      it 'is false when proc returns false' do
+        bv = RackPassword::BlockValidator.new({ custom_rule: proc { false } }, request)
         expect(bv.valid_custom_rule?).to be(false)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-ENV["RAILS_ENV"] = "test"
+ENV['RAILS_ENV'] = 'test'
 
 require 'rspec'
 require 'webmock/rspec'


### PR DESCRIPTION
Hi!
I found a small issue that might cause some Problems with access to the resources.

Our app uses quite complicated routing and we force to use language code as a part of URL, e.g. user reaching `appdomain.com` is redirected to `appdomain.com/en` - for such cases cookie is set right way (with `/` as a path) so it works for all the pages/endpoints/resources without showing form with password input.

The Problem appears when user tries to reach the page using `appdomain.com/en/`-> cookie is set with proper domain but it uses `/en` as the path so it doesn't work for main page or any other resources not using `/en` as a namespace.

Not sure if that's common case so this PR introduces:
* simple option to force using root path for created cookies + tests
* adjustments of syntax
* fixes for development environment - It seems we need to add `rack` as one of the dependencies to make all the specs passing + we should be able to run gem using the newest version of `bundle`. 

Not sure what's the versioning policy but I suppose, in case of using my changes we should upgrade to 1.4 maybe?